### PR TITLE
Updated Node.js version

### DIFF
--- a/agent/ChimeConnectIntegrationDemo.yaml
+++ b/agent/ChimeConnectIntegrationDemo.yaml
@@ -123,7 +123,7 @@ Resources:
       FunctionName: 'createChimeMeeting'
       Handler: index.handler
       Role: !GetAtt LambdaIamRole.Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
 
   DeleteChimeMeetingLambda:
     Type: AWS::Lambda::Function
@@ -135,7 +135,7 @@ Resources:
       FunctionName: 'deleteChimeMeeting'
       Handler: index.handler
       Role: !GetAtt LambdaIamRole.Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
 
   LambdaIamRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
With the updated Node.js version 12.x, support for Node.js 12.x in the AWS SDK for JavaScript has ended.

**Issue #:**
Encountering issues while creating a CloudFormation stack when uploading agent lambdas into the S3 bucket due to the use of Node.js 12.x.
**Description of changes:**
Updated the Node.js version for two lambdas in the ChimeConnectIntegrationDemo.yaml file.
**Testing**

1. Attempted to create a CloudFormation stack using ChimeConnectIntegrationDemo.yaml after my changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
